### PR TITLE
Add missing dependecies to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ vary in temperature and Co2 across the floors.
 
 1) install python libs
 ```
-sudo apt-get install python-pip
+sudo apt-get install python-pip python-dev libyaml-dev
 sudo pip install librato-metrics
 sudo pip install pyyaml
 ```


### PR DESCRIPTION
`pip install pyyaml` failed for me when compiling native extensions. This change updates the Readme accordingly.
